### PR TITLE
Add order attribute to project index page

### DIFF
--- a/vendor/extensions/projects/app/controllers/refinery/projects/projects_controller.rb
+++ b/vendor/extensions/projects/app/controllers/refinery/projects/projects_controller.rb
@@ -10,7 +10,7 @@ module Refinery
         # by swapping @page for @project in the line below:
         @dropdown_tags = Refinery::Tags::Tag.where({ name: %w(Residential Commercial Hospitality Institutional Community Mixed-Use)})
         @adaptive_tag = Refinery::Tags::Tag.find_by_name("Adaptive")
-        @projects = Refinery::Projects::Project.eager_load(:tags,:featured_image)
+        @projects = Refinery::Projects::Project.all.order("position ASC")
 
         present(@page)
       end

--- a/vendor/extensions/projects/app/controllers/refinery/projects/projects_controller.rb
+++ b/vendor/extensions/projects/app/controllers/refinery/projects/projects_controller.rb
@@ -8,9 +8,9 @@ module Refinery
       def index
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @project in the line below:
-        @tags = Refinery::Tags::Tag.all.to_a
-        @dropdown_tags = @tags.select {|tag| tag.name.in?(%w(Residential Commercial Hospitality Institutional Community Mixed-Use))}
-        @adaptive_tag = @tags.select {|tag| tag.name == "Adaptive"}
+        tags = Refinery::Tags::Tag.all.to_a
+        @dropdown_tags = tags.select {|tag| tag.name.in?(%w(Residential Commercial Hospitality Institutional Community Mixed-Use))}
+        @adaptive_tag = tags.select {|tag| tag.name == "Adaptive"}
         @projects = Refinery::Projects::Project.eager_load(:tags,:featured_image).order(:position)
         # @projects = Refinery::Projects::Project.all.order("position ASC")
         present(@page)

--- a/vendor/extensions/projects/app/controllers/refinery/projects/projects_controller.rb
+++ b/vendor/extensions/projects/app/controllers/refinery/projects/projects_controller.rb
@@ -8,10 +8,11 @@ module Refinery
       def index
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @project in the line below:
-        @dropdown_tags = Refinery::Tags::Tag.where({ name: %w(Residential Commercial Hospitality Institutional Community Mixed-Use)})
-        @adaptive_tag = Refinery::Tags::Tag.find_by_name("Adaptive")
-        @projects = Refinery::Projects::Project.all.order("position ASC")
-
+        @tags = Refinery::Tags::Tag.all.to_a
+        @dropdown_tags = @tags.select {|tag| tag.name.in?(%w(Residential Commercial Hospitality Institutional Community Mixed-Use))}
+        @adaptive_tag = @tags.select {|tag| tag.name == "Adaptive"}
+        @projects = Refinery::Projects::Project.eager_load(:tags,:featured_image).order(:position)
+        # @projects = Refinery::Projects::Project.all.order("position ASC")
         present(@page)
       end
 


### PR DESCRIPTION
@LoganDSPrice You were using `.eager_load` in the projects controller.  That wasn't able to pick up repositioning of the projects in the refinery admin page.  I changed it to `.order` since it seems that `.eager_load` doesn't affect how the tags are populated since those are through associations.  What do you think?